### PR TITLE
Enable child directive complication

### DIFF
--- a/js/angular/components/accordion/accordion.js
+++ b/js/angular/components/accordion/accordion.js
@@ -86,7 +86,7 @@
           title: '@'
         },
         require: '^zfAccordion',
-        replace: true,
+        replace: false,
         controller: function() {},
         link: link
     };


### PR DESCRIPTION
Setting replace to false so that nested directive within zf-accordion-item can be compiled without being replaced.
